### PR TITLE
Private Dataset should be included in stats count - fixes #3

### DIFF
--- a/ckanext/developerpage/plugin.py
+++ b/ckanext/developerpage/plugin.py
@@ -1,6 +1,6 @@
 import ckan.plugins as p
 import ckan.lib.helpers as ckanhelpers
-
+from ckan.logic import get_action
 import ckan.plugins.toolkit as toolkit
 
 from ckanext.developerpage import blueprint
@@ -8,7 +8,11 @@ from ckanext.developerpage.helpers import get_host_info, get_ckan_info, get_exte
 
 
 def counter_helper():
-    return ckanhelpers.get_site_statistics()
+    stats = ckanhelpers.get_site_statistics()
+    stats['dataset_count'] = get_action('package_search')(
+        {}, {"rows": 0, "include_private": True})['count']
+    return stats
+
 
 class DeveloperpagePlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer)
@@ -21,7 +25,6 @@ class DeveloperpagePlugin(p.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'developerpage')
-
 
     def get_helpers(self):
         return {


### PR DESCRIPTION
Total count on the homepage and develop page should include private datasets. The count is currently excluding the private datasets.

