### PR TITLE
Add link to the top if user is sysadmin

### DIFF
--- a/ckanext/developerpage/templates/header.html
+++ b/ckanext/developerpage/templates/header.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+{% block header_account_logged %}
+    {% if c.userobj.sysadmin %}
+    <li>
+      <a href="{{ h.url_for('/developer') }}" title="{{ _('Developer page') }}">
+        <i class="fa fa-code" aria-hidden="true"></i>
+        <span class="text">{{ _('Developer') }}</span>
+      </a>
+    </li>
+    {% endif %}
+    {{ super() }}
+{% endblock %}


### PR DESCRIPTION
Extra button on top bar for sysadmins:

![image](https://user-images.githubusercontent.com/6423992/75446032-e3b44580-5966-11ea-9d60-c700c8be2232.png)
